### PR TITLE
UCT/IB/EXP: Fix UMR contig memh dereg

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -277,8 +277,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
         status = ucp_mem_rereg_mds(context, UCS_BIT(md_idx),
                                    buffer + s->lb_displ,
                                    s->extent,
-                                   UCT_MD_MEM_ACCESS_ALL, NULL,
-                                   UCS_MEMORY_TYPE_HOST, NULL,
+                                   UCT_MD_MEM_ACCESS_ALL |
+                                   UCT_MD_MEM_FLAG_NON_CONTIG_BASE,
+                                   NULL, UCS_MEMORY_TYPE_HOST, NULL,
                                    state->dt.struct_dt.contig.memh,
                                    &state->dt.struct_dt.contig.md_map);
         if (status != UCS_OK) {

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -664,6 +664,8 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_ACCESS_REMOTE_GET    = UCS_BIT(6), /**< enable remote get access */
     UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(7), /**< enable remote atomic access */
     UCT_MD_MEM_FLAG_EMPTY           = UCS_BIT(8), /**< Create empty handle (for UMR) */
+    UCT_MD_MEM_FLAG_NON_CONTIG      = UCS_BIT(9),
+    UCT_MD_MEM_FLAG_NON_CONTIG_BASE = UCS_BIT(10),
 
     /** enable local and remote access for all operations */
     UCT_MD_MEM_ACCESS_ALL =  (UCT_MD_MEM_ACCESS_REMOTE_PUT|

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -896,20 +896,6 @@ static ucs_status_t uct_ib_mem_rcache_reg(uct_md_h uct_md, void *address,
     ucs_status_t status;
     uct_ib_mem_t *memh;
 
-char *ptr = getenv("PMIX_RANK");
-if(!strcmp(ptr, "0")){
-    static int count = 0;
-    
-    printf("ALLOC: addr=%p, size=%zu, count=%d\n", address, length, count++);
-    fflush(stdout);
-#if 1
-    static int delay = 1;
-    while( ((count - 1) == 16) && delay ) {
-	sleep(1);
-    }
-#endif
-}
-
     status = ucs_rcache_get(md->rcache, address, length, PROT_READ|PROT_WRITE,
                             &flags, &rregion);
     if (status != UCS_OK) {
@@ -925,6 +911,11 @@ if(!strcmp(ptr, "0")){
     if (flags & UCT_MD_MEM_ACCESS_REMOTE_ATOMIC) {
         memh->flags |= UCT_IB_MEM_ACCESS_REMOTE_ATOMIC;
     }
+
+    if (flags & UCT_MD_MEM_FLAG_NON_CONTIG_BASE) {
+        memh->flags |= UCT_IB_MEM_FLAG_NC_BASE_MR;
+    }
+
     *memh_p = memh;
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -49,7 +49,9 @@ enum {
     UCT_IB_MEM_MULTITHREADED        = UCS_BIT(3), /**< The memory region registration
                                                        handled by chunks in parallel
                                                        threads */
-    UCT_IB_MEM_FLAG_NC_MR           = UCS_BIT(4)
+    UCT_IB_MEM_FLAG_NC_MR           = UCS_BIT(4),
+    UCT_IB_MEM_FLAG_NC_BASE_MR      = UCS_BIT(5),
+    UCT_IB_MEM_FLAG_NEED_DEREG      = UCS_BIT(6)
 };
 
 enum {

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -466,8 +466,8 @@ uct_ib_mlx5_exp_umr_register(uct_ib_mlx5_md_t *md, uct_ib_mem_t *memh,
                              struct ibv_qp *qp, struct ibv_cq *cq, int sync);
 
 ucs_status_t
-uct_ib_mlx5_exp_umr_deregister(uct_ib_mem_t *memh, struct ibv_qp *qp,
-                               struct ibv_cq *cq);
+uct_ib_mlx5_exp_umr_deregister(uct_ib_mlx5_md_t *md, uct_ib_mem_t *memh,
+                               struct ibv_qp *qp, struct ibv_cq *cq);
 #endif
 
 static inline uint8_t uct_ib_mlx5_iface_get_atomic_mr_id(uct_ib_iface_t *iface)

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -408,7 +408,7 @@ ucs_status_t uct_rc_mlx5_ep_mem_dereg_nc(uct_ep_h tl_ep, uct_mem_h memh,
 #if HAVE_EXP_UMR
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     uct_ib_mem_t *ib_memh = memh;
-    ucs_status_t status;
+    ucs_status_t status   = UCS_OK;
 
     if (!(ib_memh->flags & UCT_IB_MEM_FLAG_NC_MR)) {
         ucs_error("Invalid memh, flags 0x%x", ib_memh->flags);
@@ -417,12 +417,12 @@ ucs_status_t uct_rc_mlx5_ep_mem_dereg_nc(uct_ep_h tl_ep, uct_mem_h memh,
 
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
 
-    status = uct_ib_mlx5_exp_umr_deregister(ib_memh,
+ /*   status = uct_ib_mlx5_exp_umr_deregister(ib_memh,
                                             ep->tx.wq.super.verbs.qp,
                                             iface->super.super.cq[UCT_IB_DIR_TX]);
     if (ucs_unlikely(status != UCS_OK)) {
         ucs_error("failed dereg umr %s", ucs_status_string(status));
-    }
+    }*/
     return status;
 #else
     return UCS_ERR_UNSUPPORTED;


### PR DESCRIPTION
Do not deregister contig memh used by UMR. Instead deregister it when UMR is being destroyed.

