### PR TITLE
Alternative rcache fix

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -278,8 +278,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
         status = ucp_mem_rereg_mds(context, UCS_BIT(md_idx),
                                    buffer + s->lb_displ,
                                    s->extent,
-                                   UCT_MD_MEM_ACCESS_ALL |
-                                   UCT_MD_MEM_FLAG_NC_BASE, NULL,
+                                   UCT_MD_MEM_ACCESS_ALL, NULL,
                                    UCS_MEMORY_TYPE_HOST, NULL,
                                    state->dt.struct_dt.contig.memh,
                                    &state->dt.struct_dt.contig.md_map);

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -297,8 +297,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
                                            state->dt.struct_dt.non_contig.memh,
                                            &state->dt.struct_dt.non_contig.md_map);
                                               */
-        status = ucp_dt_struct_register(context->tl_mds[md_idx].md, buffer, datatype,
-                                        state->dt.struct_dt.contig.memh[0],
+        status = ucp_dt_struct_register(context, md_idx, buffer, datatype,
                                         state->dt.struct_dt.non_contig.memh,
                                         &state->dt.struct_dt.non_contig.md_map);
         if (status != UCS_OK) {

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -12,19 +12,11 @@
 #include "dt_iov.h"
 #include "dt_generic.h"
 #include "dt_struct.h"
+#include "dt_common.h"
 
 #include <ucp/core/ucp_types.h>
 #include <uct/api/uct.h>
 #include <ucp/api/ucp.h>
-
-
-/**
- * Memory registration state of a buffer/operation
- */
-typedef struct ucp_dt_reg {
-    ucp_md_map_t                  md_map;    /* Map of used memory domains */
-    uct_mem_h                     memh[UCP_MAX_OP_MDS];
-} ucp_dt_reg_t;
 
 
 /**

--- a/src/ucp/dt/dt_common.h
+++ b/src/ucp/dt/dt_common.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2016.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef DT_COMMON_H
+#define DT_COMMON_H
+
+#include "dt_contig.h"
+#include "dt_iov.h"
+#include "dt_generic.h"
+#include "dt_struct.h"
+
+#include <ucp/core/ucp_types.h>
+#include <uct/api/uct.h>
+#include <ucp/api/ucp.h>
+
+
+/**
+ * Memory registration state of a buffer/operation
+ */
+typedef struct ucp_dt_reg {
+    ucp_md_map_t                  md_map;    /* Map of used memory domains */
+    uct_mem_h                     memh[UCP_MAX_OP_MDS];
+} ucp_dt_reg_t;
+
+
+#endif // DT_COMMON_H

--- a/src/ucp/dt/dt_struct.c
+++ b/src/ucp/dt/dt_struct.c
@@ -18,6 +18,7 @@
 #include <ucs/sys/math.h>
 #include <uct/api/uct.h>
 #include <ucp/core/ucp_ep.inl>
+#include <ucp/core/ucp_mm.h>
 
 #include <string.h>
 #include <unistd.h>
@@ -36,8 +37,9 @@ static ucs_stats_class_t ucp_dt_struct_stats_class = {
 ucs_status_t _struct_register_ep_rec(uct_ep_h ep, void *buf, ucp_dt_struct_t *s,
                                      uct_mem_h contig_memh, uct_mem_h* memh);
 
-ucs_status_t _struct_register_rec(uct_md_h md, void *buf, ucp_dt_struct_t *s,
-                                  uct_mem_h contig_memh, uct_mem_h* memh);
+ucs_status_t _struct_register_rec(ucp_dt_struct_t *s,
+                                  ucp_dt_struct_hash_value_t *val,
+                                  void *buf);
 
 static void _set_struct_attributes(ucp_dt_struct_t *s)
 {
@@ -302,14 +304,20 @@ void ucp_dt_destroy_struct(ucp_datatype_t datatype_p)
 {
     ucp_dt_struct_t *dt = ucp_dt_struct(datatype_p);
     ucp_dt_struct_hash_value_t val;
+    ucs_status_t status;
 
     ucs_info("Destroy struct dt %p, len %ld (step %ld), depth %ld, uct_iovs %ld",
              dt, dt->len, dt->step_len, dt->depth, dt->uct_iov_count);
 
     kh_foreach_value(&dt->hash, val, {
+        uct_md_h md = val.ucp_ctx->tl_mds[val.md_idx].md;
         ucs_info("struct dt %p, dereg NC memh %p on md %p",
-                 dt, val.memh, val.md);
-        uct_md_mem_dereg_nc(val.md, val.memh);
+                 dt, val.noncontig.memh, md);
+        uct_md_mem_dereg_nc(md, val.noncontig.memh[0]);
+        status = ucp_mem_rereg_mds(val.ucp_ctx, 0, NULL, 0, 0, NULL,
+                                   UCS_MEMORY_TYPE_HOST, NULL,
+                                   val.contig.memh, &val.contig.md_map);
+        assert(UCS_OK == status);
     })
     kh_destroy_inplace(dt_struct, &dt->hash);
     ucs_free(dt->desc);
@@ -350,41 +358,23 @@ size_t ucp_dt_struct_scatter(void *dst, ucp_datatype_t dt,
 
 /* Dealing with UCT */
 
-inline static void _to_cache(ucp_dt_struct_t *s, void *ptr, uct_md_h md,
-                             uct_mem_h memh)
+inline static void _to_cache(ucp_dt_struct_t *s, void *ptr,
+                             ucp_dt_struct_hash_value_t *val)
 {
-    ucp_dt_struct_hash_value_t val = {md, memh};
+    uct_md_h md = val->ucp_ctx->tl_mds[val->md_idx].md;
     khiter_t k;
     int ret;
 
     k = kh_put(dt_struct, &s->hash, (uint64_t)ptr, &ret);
     ucs_assert_always((ret == 1) || (ret == 2));
     /* TODO: check ret */
-    kh_value(&s->hash, k) = val;
+    kh_value(&s->hash, k) = *val;
 
-    ucs_info("dt %p adding to cache (buf %p md %p memh %p)", s, ptr, md, memh);
+    ucs_info("dt %p adding to cache (buf %p md %p memh %p)", s, ptr, md,
+             val->noncontig.memh);
 }
 
 #if 0
-static int _is_primitive_strided(ucp_dt_struct_t *s)
-{
-    size_t i;
-    /* Has only 2 levels of nesting */
-    if (s->depth != 2){
-        return 0;
-    }
-
-    /* On the leaf level, all datatypes are contig */
-    for (i = 0; i < s->desc_count; i++) {
-        if ((s->desc[0].dt & UCP_DATATYPE_CLASS_MASK) !=
-                UCP_DATATYPE_CONTIG) {
-            return 0;
-        }
-    }
-    return 1;
-}
-#endif
-
 static uct_iov_t* _fill_uct_iov_rec(uct_ep_h ep, void *buf, ucp_dt_struct_t *s,
                                     uct_mem_h contig_memh, uct_iov_t *iovs)
 {
@@ -421,6 +411,7 @@ static uct_iov_t* _fill_uct_iov_rec(uct_ep_h ep, void *buf, ucp_dt_struct_t *s,
     return iov;
 }
 
+
 ucs_status_t _struct_register_ep_rec(uct_ep_h ep, void *buf, ucp_dt_struct_t *s,
                                      uct_mem_h contig_memh, uct_mem_h* memh)
 {
@@ -448,6 +439,7 @@ ucs_status_t _struct_register_ep_rec(uct_ep_h ep, void *buf, ucp_dt_struct_t *s,
     return UCS_OK;
 }
 
+
 ucs_status_t ucp_dt_struct_register_ep(ucp_ep_h ep, ucp_lane_index_t lane,
                                        void *buf, ucp_datatype_t dt, uct_mem_h
                                        contig_memh, uct_mem_h* memh,
@@ -472,14 +464,18 @@ ucs_status_t ucp_dt_struct_register_ep(ucp_ep_h ep, ucp_lane_index_t lane,
 
     return status;
 }
+#endif
 
-static uct_iov_t* _fill_md_uct_iov_rec(uct_md_h md, void *buf, ucp_dt_struct_t *s,
-                                       uct_mem_h contig_memh, uct_iov_t *iovs)
+static uct_iov_t* _fill_md_uct_iov_rec(ucp_dt_struct_t *s,
+                                       ucp_dt_struct_hash_value_t *val,
+                                       void *buf,
+                                       uct_iov_t *iovs)
 {
     uct_iov_t *iov = iovs;
     ucp_dt_struct_t *s_in;
     ucs_status_t status;
     void *ptr, *eptr;
+    ucp_md_map_t md_map = 0;
     int i;
 
     for (i = 0; i < s->desc_count; i++, iov++) {
@@ -488,13 +484,15 @@ static uct_iov_t* _fill_md_uct_iov_rec(uct_md_h md, void *buf, ucp_dt_struct_t *
         if (UCP_DT_IS_STRUCT(s->desc[i].dt)) {
             s_in = ucp_dt_struct(s->desc[i].dt);
             if (s_in->rep_count == 1) {
-                iov = _fill_md_uct_iov_rec(md, ptr, s_in, contig_memh, iov);
+                iov = _fill_md_uct_iov_rec(s_in, val, ptr, iov);
             } else {
                 /* calculate effective offset */
                 iov->buffer = eptr;
                 iov->length = s_in->len;
                 iov->stride = s->desc[i].extent;
-                status = _struct_register_rec(md, ptr, s_in, contig_memh, &iov->memh);
+                status = ucp_dt_struct_register(val->ucp_ctx, val->md_idx, ptr,
+                                                s->desc[i].dt, &iov->memh,
+                                                &md_map);
                 ucs_assert_always(status == UCS_OK);
             }
         } else {
@@ -502,23 +500,25 @@ static uct_iov_t* _fill_md_uct_iov_rec(uct_md_h md, void *buf, ucp_dt_struct_t *
             iov->buffer = ptr;
             iov->length = ucp_contig_dt_length(s->desc[i].dt, 1);
             iov->stride = s->desc[i].extent;
-            iov->memh   = contig_memh;
+            iov->memh   = val->contig.memh[0];
         }
     }
 
     return iov;
 }
 
-ucs_status_t _struct_register_rec(uct_md_h md, void *buf, ucp_dt_struct_t *s,
-                                  uct_mem_h contig_memh, uct_mem_h* memh)
+ucs_status_t _struct_register_rec(ucp_dt_struct_t *s,
+                                  ucp_dt_struct_hash_value_t *val,
+                                  void *buf)
 {
+    uct_md_h md = val->ucp_ctx->tl_mds[val->md_idx].md;
     size_t iov_cnt  = s->uct_iov_count;
     uct_iov_t *iovs = ucs_calloc(iov_cnt, sizeof(*iovs), "umr_iovs");
     ucs_status_t status;
 
-    _fill_md_uct_iov_rec(md, buf, s, contig_memh, iovs);
+    _fill_md_uct_iov_rec(s, val, buf, iovs);
 
-    status = uct_md_mem_reg_nc(md, iovs, iov_cnt, s->rep_count, &memh[0]);
+    status = uct_md_mem_reg_nc(md, iovs, iov_cnt, s->rep_count, &val->noncontig.memh[0]);
     if (status != UCS_OK) {
         ucs_error("Failed to register NC memh: %s", ucs_status_string(status));
         return status;
@@ -531,25 +531,42 @@ ucs_status_t _struct_register_rec(uct_md_h md, void *buf, ucp_dt_struct_t *s,
     return UCS_OK;
 }
 
-ucs_status_t ucp_dt_struct_register(uct_md_h md, void *buf, ucp_datatype_t dt,
-                                    uct_mem_h contig_memh, uct_mem_h* memh,
+ucs_status_t ucp_dt_struct_register(ucp_context_t *context, ucp_md_index_t md_idx,
+                                    void *buf, ucp_datatype_t dt,
+                                    uct_mem_h* memh,
                                     ucp_md_map_t *md_map_p)
 {
     ucp_dt_struct_t *s = ucp_dt_struct(dt);
     ucs_status_t status;
+    ucp_dt_struct_hash_value_t val;
 
     ucs_assert_always(UCP_DT_IS_STRUCT(dt));
+
+    /* register contig memory block covering the whole struct
+     * This will ensure that the memory wil not be invalidated
+     */
+    val.ucp_ctx = context;
+    val.md_idx = md_idx;
+    val.contig.md_map = 0;
+    status = ucp_mem_rereg_mds(val.ucp_ctx, UCS_BIT(val.md_idx),
+                               buf + s->lb_displ,
+                               s->extent,
+                               UCT_MD_MEM_ACCESS_ALL, NULL,
+                               UCS_MEMORY_TYPE_HOST, NULL,
+                               val.contig.memh,
+                               &val.contig.md_map);
 
     printf("STRUCT reg: addr=%p, datatype=%p\n", buf, s);
 
     ucs_info("Register struct on md, dt %ld, len %ld", dt, s->len);
 
-    status = _struct_register_rec(md, buf, s, contig_memh, memh);
+    status = _struct_register_rec(s, &val, buf);
     if (status == UCS_OK) {
         //*md_map_p = UCS_BIT(md_idx);
-        _to_cache(s, buf, md, memh[0]);
+        _to_cache(s, buf, &val);
 
     }
+    *memh = val.noncontig.memh[0];
 
     return status;
 }

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -664,7 +664,6 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_ACCESS_REMOTE_GET    = UCS_BIT(6), /**< enable remote get access */
     UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(7), /**< enable remote atomic access */
     UCT_MD_MEM_FLAG_EMPTY           = UCS_BIT(8), /**< Create empty handle (for UMR) */
-    UCT_MD_MEM_FLAG_NC_BASE         = UCS_BIT(9), /**< Used by UMR */
 
     /** enable local and remote access for all operations */
     UCT_MD_MEM_ACCESS_ALL =  (UCT_MD_MEM_ACCESS_REMOTE_PUT|

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -912,11 +912,6 @@ static ucs_status_t uct_ib_mem_rcache_reg(uct_md_h uct_md, void *address,
         memh->flags |= UCT_IB_MEM_ACCESS_REMOTE_ATOMIC;
     }
 
-    if (flags & UCT_MD_MEM_FLAG_NC_BASE) {
-        /* This region is used by UMR */
-        ucs_rcache_region_hold(md->rcache, rregion);
-    }
-
     *memh_p = memh;
     return UCS_OK;
 }

--- a/src/uct/ib/mlx5/exp/ib_exp_md.c
+++ b/src/uct/ib/mlx5/exp/ib_exp_md.c
@@ -389,7 +389,6 @@ uct_ib_mlx5_exp_umr_alloc(uct_ib_mlx5_md_t *md, const uct_iov_t *iov,
     umr->iov_count    = iov_count;
     umr->comp.count   = 1; /* for async reg */
     umr->memh.umr     = umr;
-    umr->contig_memh  = ucs_derived_of(iov->memh, uct_ib_mlx5_mem_t); /* assume all iovs use the same memh for now */
 
     if (repeat_count == 1) { /* MRs list */
         status = uct_ib_mlx5_exp_umr_fill_region(umr, iov, iov_count);
@@ -555,8 +554,6 @@ uct_ib_mlx5_exp_umr_deregister(uct_ib_mem_t *memh, struct ibv_qp *qp,
             ucs_fatal("ibv_exp_poll_cq(umr_cq) failed: %m");
         }
     }
-
-    umr->md->super.super.ops->mem_dereg(&umr->md->super.super, &umr->contig_memh->super);
 
     ucs_free(umr);
 


### PR DESCRIPTION
The issues with #5:
1. Sub-dt UMRs are not tracked
2. The assumption that all iov's have same memh is not correct [[link](https://github.com/brminich/ucx/pull/5/files#diff-ad9bdaed881e36d0aa5f7b36a73599fdR392)]